### PR TITLE
Filestore2 tests v2

### DIFF
--- a/tests/filestore-v2.1-forced/test.yaml
+++ b/tests/filestore-v2.1-forced/test.yaml
@@ -1,4 +1,6 @@
 requires:
+  features:
+    - HAVE_NSS
   files:
     - src/output-filestore.c
 

--- a/tests/filestore-v2.2-forced-with-open-files/test.yaml
+++ b/tests/filestore-v2.2-forced-with-open-files/test.yaml
@@ -1,4 +1,6 @@
 requires:
+  features:
+    - HAVE_NSS
   files:
     - src/output-filestore.c
 

--- a/tests/filestore-v2.3-fserror/test.yaml
+++ b/tests/filestore-v2.3-fserror/test.yaml
@@ -1,4 +1,6 @@
 requires:
+  features:
+    - HAVE_NSS
   files:
     - src/output-filestore.c
 

--- a/tests/filestore-v2.4-forced-with-meta/README.md
+++ b/tests/filestore-v2.4-forced-with-meta/README.md
@@ -1,0 +1,1 @@
+Test if meta file correctly states file has been stored.

--- a/tests/filestore-v2.4-forced-with-meta/suricata.yaml
+++ b/tests/filestore-v2.4-forced-with-meta/suricata.yaml
@@ -1,0 +1,26 @@
+%YAML 1.1
+---
+
+include: ../../etc/suricata-4.0.3.yaml
+
+outputs:
+  - eve-log:
+      enabled: yes
+      types:
+        - files
+        - stats
+  - file-store:
+      version: 2
+      enabled: yes
+      force-filestore: yes
+      stream-depth: 0
+      write-fileinfo: true
+      
+app-layer:
+  protocols:
+    http:
+      enabled: yes
+      libhtp:
+        default-config:
+          personality: IDS
+          response-body-limit: 200kb

--- a/tests/filestore-v2.4-forced-with-meta/test.yaml
+++ b/tests/filestore-v2.4-forced-with-meta/test.yaml
@@ -1,0 +1,20 @@
+requires:
+  features:
+    - HAVE_NSS
+    - HAVE_LIBJANSSON
+  files:
+    - src/output-filestore.c
+
+pcap: ../filestore-v2.1-forced/suricata-update-pdf.pcap
+
+checks:
+
+  # Check how many lines were logged to fast.log.
+  - shell:
+      args: cat output/filestore/48/48d179a2f8d17331446c7a75a082851eee9ad841705ed5fbce730f51a0598d62.1515441287.1.json | jq -c 'select(.fileinfo.sha256=="48d179a2f8d17331446c7a75a082851eee9ad841705ed5fbce730f51a0598d62")' | wc -l | xargs
+      expect: 1
+
+  - shell:
+      args: cat output/filestore/48/48d179a2f8d17331446c7a75a082851eee9ad841705ed5fbce730f51a0598d62.1515441287.1.json | jq -c 'select(.fileinfo.stored==true)' | wc -l | xargs
+      expect: 1
+


### PR DESCRIPTION
Fixes the filestore2 tests to add the HAVE_NSS requirement.

Adds a filestore2 showing that the meta file has an issue with the 'stored' field. So this test fails with https://github.com/OISF/suricata/pull/3173 currently.