### PR TITLE
tls-fingerprint: test sticky buffer variant

### DIFF
--- a/tests/tls-fingerprint-alert/test.rules
+++ b/tests/tls-fingerprint-alert/test.rules
@@ -1,5 +1,10 @@
 # Rule should only fire in the to client direction, with the server address
 # being the source address in the event.
 alert tls any any -> any any (msg:"TLS FINGERPRINT TEST"; \
-tls.fingerprint:"90:86:a4:3b:f5:cf:1b:2e:4e:f7:97:96:f9:de:ba:b9:66:35:86:3f"; \
-sid:1; rev:1;)
+	tls.fingerprint:"90:86:a4:3b:f5:cf:1b:2e:4e:f7:97:96:f9:de:ba:b9:66:35:86:3f"; \
+	sid:1; rev:1;)
+
+# Equivalent rule by using a sticky buffer.
+alert tls any any -> any any (msg:"TLS FINGERPRINT STICKY BUFFER TEST"; \
+	tls.cert_fingerprint; content:"90:86:a4:3b:f5:cf:1b:2e:4e:f7:97:96:f9:de:ba:b9:66:35:86:3f"; \
+	sid:2; rev:1;)

--- a/tests/tls-fingerprint-alert/test.yaml
+++ b/tests/tls-fingerprint-alert/test.yaml
@@ -7,3 +7,9 @@ checks:
       count: 1
       match:
         event_type: alert
+        alert.signature_id: 1
+  - filter:
+      count: 1
+      match:
+        event_type: alert
+        alert.signature_id: 2


### PR DESCRIPTION
Add another rule and filter to test the sticky buffer variant
of a tls fingerprint match. Also shows that the 2 are more or
less equivalent.
